### PR TITLE
Support templated filename expressions for generated documents

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,11 @@ python generate_forms.py alumnos.csv plantilla.docx --name-column Nombres
 - `alumnos.csv`: archivo con encabezados en la primera fila.
 - `plantilla.docx`: documento con los marcadores `[[...]]` que deseas reemplazar.
 - `--name-column`: (opcional) nombre de la columna usada para generar el nombre
-  de cada archivo. Si se omite, se utilizará el primer valor no vacío de la
-  fila o, como último recurso, `row_001.docx`, `row_002.docx`, etc.
+  de cada archivo. También acepta plantillas con expresiones como
+  `F2-$Nombres[0]-$Apellidos[0]`. Cada `'$Campo'` inserta el valor completo de
+  la columna, y `'$Campo[0]'` toma solo la primera palabra (separada por
+  espacios). Si se omite, se utilizará el primer valor no vacío de la fila o,
+  como último recurso, `row_001.docx`, `row_002.docx`, etc.
 - `--outdir`: (opcional) carpeta de salida. Por defecto se usa `salida/`.
 - `--encoding`: (opcional) codificación del CSV. Por defecto `utf-8-sig`.
 


### PR DESCRIPTION
## Summary
- allow the `--name-column` option to accept filename templates like `F2-$Nombres[0]-$Apellidos[0]`
- evaluate template fragments by splitting column values on whitespace before sanitising the result
- document the new filename templating behaviour in the README

## Testing
- python -m compileall generate_forms.py

------
https://chatgpt.com/codex/tasks/task_e_68e00d891b00832f81be1854985bc79b