### PR TITLE
Fix filename generation for accented characters

### DIFF
--- a/generate_forms.py
+++ b/generate_forms.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import argparse
 import csv
 import re
+import unicodedata
 import sys
 from pathlib import Path
 from typing import Dict, Iterable, Iterator, Optional
@@ -43,10 +44,17 @@ def normalize_label(label: Optional[str]) -> str:
     return clean.casefold()
 
 
+def strip_diacritics(text: str) -> str:
+    """Return ``text`` without diacritical marks."""
+
+    normalized = unicodedata.normalize("NFKD", text)
+    return "".join(char for char in normalized if not unicodedata.combining(char))
+
+
 def sanitize_filename(raw: str) -> str:
     """Return a filesystem-friendly version of ``raw``."""
 
-    value = raw.strip()
+    value = strip_diacritics(raw.strip())
     value = re.sub(r"\s+", "_", value)
     value = re.sub(r"[^A-Za-z0-9._-]", "", value)
     return value


### PR DESCRIPTION
## Summary
- strip diacritical marks before sanitising generated filenames
- reuse the cleaned text to ensure accented characters are transliterated instead of dropped

## Testing
- `python3 generate_forms.py tmp.csv Formulario_N_2_2026.docx --name-column "F2-$Nombres[0]-$Apellidos[0]"` *(fails: missing python-docx dependency in container)*

------
https://chatgpt.com/codex/tasks/task_e_68e01133a140832f9b5645d2f4df39a4