### PR TITLE
Support brace name templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,9 @@ python generate_forms.py alumnos.csv plantilla.docx --name-column Nombres
 - `plantilla.docx`: documento con los marcadores `[[...]]` que deseas reemplazar.
 - `--name-column`: (opcional) nombre de la columna usada para generar el nombre
   de cada archivo. También acepta plantillas con expresiones como
-  `F2-$Nombres[0]-$Apellidos[0]`. Cada `'$Campo'` inserta el valor completo de
-  la columna, y `'$Campo[0]'` toma solo la primera palabra (separada por
+  `'F2-$Nombres[0]-$Apellidos[0]'` o `"F2-{{Nombres[0]}}-{{Apellidos[0]}}"`.
+  Cada `'$Campo'` (o `{{Campo}}`) inserta el valor completo de la columna, y
+  `'$Campo[0]'`/`{{Campo[0]}}` toma solo la primera palabra (separada por
   espacios). Si se omite, se utilizará el primer valor no vacío de la fila o,
   como último recurso, `row_001.docx`, `row_002.docx`, etc.
 - `--outdir`: (opcional) carpeta de salida. Por defecto se usa `salida/`.


### PR DESCRIPTION
## Summary
- allow `--name-column` templates to use double braces to avoid shell `$` expansion
- share placeholder resolution logic between dollar and brace templates
- document the safer quoting options for name templates in the README

## Testing
- python -m compileall generate_forms.py

------
https://chatgpt.com/codex/tasks/task_e_68e0152afc88832fb071b6dc08103264